### PR TITLE
changing max_input_vars for php - it is to small for drupal

### DIFF
--- a/Dockerfile.app
+++ b/Dockerfile.app
@@ -73,6 +73,7 @@ RUN { \
     echo 'post_max_size=6152M'; \
     echo 'upload_max_filesize=6144M'; \
     echo 'max_execution_time=3600'; \
+    echo 'max_input_vars = 50000'; \
     echo 'max_input_time=3600'; \
     echo 'error_reporting=E_ALL'; \
     echo 'display_errors=On'; \


### PR DESCRIPTION
changing max_input_vars for php - it is to small for drupal

when you saving big article there is problem 